### PR TITLE
feat: SpotBugsによる静的解析のワークフローを追加

### DIFF
--- a/.github/workflows/analysis-spotbugs.yml
+++ b/.github/workflows/analysis-spotbugs.yml
@@ -1,0 +1,40 @@
+name: static analysis with SpotBugs
+
+on:
+  pull_request
+
+jobs:
+  spotbugs-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Reviewdogが差分を正しく検出するために必要
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'corretto'
+          cache: 'maven'
+
+      - name: Build with Maven and Run SpotBugs
+        run: |
+          mvn package -DskipTests && mvn spotbugs:spotbugs
+
+      # 解析結果のPR反映として reviewdog を使用
+      - name: Setup Reviewdog
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
+        with:
+          reviewdog_version: latest
+
+      - name: Run Reviewdog with SpotBugs Report
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat ./target/spotbugs.sarif \
+          | reviewdog -f=sarif -name=spotbugs-pr-review -reporter=github-pr-review -tee


### PR DESCRIPTION
.github/workflows/analysis-spotbugs.ymlファイルを新規作成し、Pull Request時にSpotBugsを使用した静的解析を実行するジョブを設定しました。Mavenを使用してビルドし、Reviewdogを用いて解析結果をPRに反映します。