### PR TITLE
Feat/non-diff-skip

### DIFF
--- a/.github/workflows/analysis-spotbugs.yml
+++ b/.github/workflows/analysis-spotbugs.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Build with Maven and Run SpotBugs
         if: steps.check-diff.outputs.diff_files != ''
+        id: spotbugs
         run: |
           DIFF_FILES="${{ steps.check-diff.outputs.diff_files }}"
           echo "${DIFF_FILES}"
@@ -61,8 +62,8 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "sarif_output_dir=${{ steps.check-diff.outputs.sarif_output_dir }}"
-          cat ${{ steps.check-diff.outputs.sarif_output_dir }}/spotbugs.sarif \
+          echo "sarif_output_dir=${{ steps.spotbugs.outputs.sarif_output_dir }}"
+          cat ${{ steps.spotbugs.outputs.sarif_output_dir }}/spotbugs.sarif \
           | reviewdog -f=sarif -name=spotbugs-pr-review -reporter=github-pr-review -tee
 
       - name: always

--- a/.github/workflows/analysis-spotbugs.yml
+++ b/.github/workflows/analysis-spotbugs.yml
@@ -15,14 +15,8 @@ jobs:
         with:
           fetch-depth: 0 # Reviewdogが差分を正しく検出するために必要
 
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: '8'
-          distribution: 'corretto'
-          cache: 'maven'
-
-      - name: Build with Maven and Run SpotBugs
+      - name: Check for Java file changes
+        id: check-diff
         run: |
           DIFF_FILES=$(git diff origin/${{ github.base_ref }} --name-only | \
               grep .java | \
@@ -30,18 +24,43 @@ jobs:
                   -e 's#\.java$##' \
                   -e 's#/#.#g' | \
               tr '\n' ',')
+          echo "diff_files=${DIFF_FILES}" >> $GITHUB_OUTPUT
+          if [ -z "${DIFF_FILES}" ]; then
+            echo "No Java files changed"
+          else
+            echo "Java files changed: ${DIFF_FILES}"
+          fi
+
+      - name: Set up Java
+        if: steps.check-diff.outputs.diff_files != ''
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'corretto'
+          cache: 'maven'
+
+      - name: Build with Maven and Run SpotBugs
+        if: steps.check-diff.outputs.diff_files != ''
+        run: |
+          DIFF_FILES="${{ steps.check-diff.outputs.diff_files }}"
           echo "${DIFF_FILES}"
           mvn package -DskipTests && mvn spotbugs:spotbugs -Dspotbugs.onlyAnalyze="${DIFF_FILES}"
 
       # 解析結果のPR反映として reviewdog を使用
       - name: Setup Reviewdog
+        if: steps.check-diff.outputs.diff_files != ''
         uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
         with:
           reviewdog_version: latest
 
       - name: Run Reviewdog with SpotBugs Report
+        if: steps.check-diff.outputs.diff_files != ''
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat ./target/spotbugs.sarif \
           | reviewdog -f=sarif -name=spotbugs-pr-review -reporter=github-pr-review -tee
+
+      - name: always
+        if: always()
+        run: echo "完了"

--- a/.github/workflows/analysis-spotbugs.yml
+++ b/.github/workflows/analysis-spotbugs.yml
@@ -44,7 +44,10 @@ jobs:
         run: |
           DIFF_FILES="${{ steps.check-diff.outputs.diff_files }}"
           echo "${DIFF_FILES}"
-          mvn package -DskipTests && mvn spotbugs:spotbugs -Dspotbugs.onlyAnalyze="${DIFF_FILES}"
+          SARIF_OUTPUT_DIR="/tmp"
+          echo "sarif_output_dir=${SARIF_OUTPUT_DIR}" >> $GITHUB_OUTPUT
+
+          mvn package -DskipTests && mvn spotbugs:spotbugs -Dspotbugs.onlyAnalyze="${DIFF_FILES}" -Dspotbugs.sarifOutputDirectory="${SARIF_OUTPUT_DIR}"
 
       # 解析結果のPR反映として reviewdog を使用
       - name: Setup Reviewdog
@@ -58,7 +61,8 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cat ./target/spotbugs.sarif \
+          echo "sarif_output_dir=${{ steps.check-diff.outputs.sarif_output_dir }}"
+          cat ${{ steps.check-diff.outputs.sarif_output_dir }}/spotbugs.sarif \
           | reviewdog -f=sarif -name=spotbugs-pr-review -reporter=github-pr-review -tee
 
       - name: always

--- a/src/main/java/com/example/SpotbugsError.java
+++ b/src/main/java/com/example/SpotbugsError.java
@@ -2,10 +2,10 @@ package com.example;
 
 public class SpotbugsError {
     public static void main(String[] args) {
-        System.out.println("問題ないコードを変更");
+        System.out.println("問題ないコードを変更"); // test
 
-        String str = null;
-        System.out.println(str.length());
-        System.out.println("問題ないコードを変更");
+        String str = null; // test
+        System.out.println(str.length()); // test
+        System.out.println("問題ないコードを変更"); // test
     }
 }


### PR DESCRIPTION
- Javaファイルの変更を確認するステップを追加し、変更がない場合のメッセージを表示するようにしました。
- MavenビルドおよびSpotBugs実行の条件を、Javaファイルが変更された場合のみに設定しました。
- Reviewdogのセットアップおよび実行も、Javaファイルが変更された場合のみに実行されるようにしました。